### PR TITLE
Update dependencies instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ liquid cooler.
 This project depends on glog, yaml-cpp and libusb. On fedora:
 
 ```
-$ sudo dnf install yaml-devel glog-devel libusb-devel
+$ sudo dnf install yaml-cpp-devel glog-devel libusb-devel
 ```
 
 ### Building


### PR DESCRIPTION
At least on Fedora 27, yaml-devel should be yaml-cpp-devel